### PR TITLE
Fix: Correct NodePath to enable inventory functionality

### DIFF
--- a/inventory_ui.gd
+++ b/inventory_ui.gd
@@ -13,7 +13,7 @@ func _ready():
 	await get_tree().process_frame
 	
 	# Find all item slots dynamically
-	var items_container = get_node("InventoryRoot/Panel/Panel#MarginContainer/Panel_MarginContainer#VBoxContainer/Panel_MarginContainer_VBoxContainer#Items")
+	var items_container = get_node("Panel/MarginContainer/VBoxContainer/Items")
 	if items_container:
 		print("Found items container: ", items_container.name)
 		


### PR DESCRIPTION
The inventory drag-and-drop and right-click-to-use features were not working because the `inventory_ui.gd` script could not find the item slot nodes. This was caused by an incorrect NodePath being used in the `_ready` function to get the items container.

The script is attached to the `InventoryRoot` node, but the path being used was an incorrect, absolute-style path.

This commit corrects the NodePath to be the proper relative path from `InventoryRoot` to the items container. This allows the script to find the slots, connect the GUI signals, and enables the existing (but previously non-functional) drag-and-drop and right-click logic.